### PR TITLE
fix(Components): Fix the issue with the `TextField` component not showing the value loaded from the form.

### DIFF
--- a/packages/evergreen-component-mapper/src/text-field/text-field.tsx
+++ b/packages/evergreen-component-mapper/src/text-field/text-field.tsx
@@ -15,15 +15,15 @@ const TextField: React.FC<TextFieldProps> = (props) => {
 	const { input, meta, isRequired, items, ...rest } = useFieldApi(props) as TextFieldProps;
 
 	return (
-		<Autocomplete {...input} items={items || []} allowOtherValues>
-			{({ getInputProps, getRef, inputValue, openMenu }) => (
+		<Autocomplete {...input} items={items || []} allowOtherValues {...rest}>
+			{({ getInputProps, getRef, openMenu }) => (
 				<TextInputField
 					ref={getRef}
 					required={isRequired}
 					isInvalid={Boolean(meta.error)}
 					validationMessage={meta.error}
 					{...getInputProps({ onFocus: () => openMenu() })}
-					value={inputValue}
+					value={input.value}
 					{...rest}
 				/>
 			)}

--- a/packages/evergreen-component-mapper/src/text-field/text-field.tsx
+++ b/packages/evergreen-component-mapper/src/text-field/text-field.tsx
@@ -15,7 +15,7 @@ const TextField: React.FC<TextFieldProps> = (props) => {
 	const { input, meta, isRequired, items, ...rest } = useFieldApi(props) as TextFieldProps;
 
 	return (
-		<Autocomplete {...input} items={items || []} allowOtherValues>
+		<Autocomplete {...input} items={items || []} allowOtherValues selectedItem={input.value}>
 			{({ getInputProps, getRef, inputValue, openMenu }) => (
 				<TextInputField
 					ref={getRef}

--- a/packages/evergreen-component-mapper/src/text-field/text-field.tsx
+++ b/packages/evergreen-component-mapper/src/text-field/text-field.tsx
@@ -15,15 +15,15 @@ const TextField: React.FC<TextFieldProps> = (props) => {
 	const { input, meta, isRequired, items, ...rest } = useFieldApi(props) as TextFieldProps;
 
 	return (
-		<Autocomplete {...input} items={items || []} allowOtherValues {...rest}>
-			{({ getInputProps, getRef, openMenu }) => (
+		<Autocomplete {...input} items={items || []} allowOtherValues>
+			{({ getInputProps, getRef, inputValue, openMenu }) => (
 				<TextInputField
 					ref={getRef}
 					required={isRequired}
 					isInvalid={Boolean(meta.error)}
 					validationMessage={meta.error}
 					{...getInputProps({ onFocus: () => openMenu() })}
-					value={input.value}
+					value={inputValue}
 					{...rest}
 				/>
 			)}


### PR DESCRIPTION
Currently, while the `TextField` component in the `evergreen-component-mapper` does work properly with entering values (and with suggestions; based on the fix from this PR https://github.com/data-driven-forms/editor/pull/26), it does not load the form value (specifically `input.value` from the `FormState`) stored in the DDF store for the given field. This PR should fix that. 